### PR TITLE
Release 0.0.41 alpha4 holo nixpkgs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     docker:
       - image: nixos/nix
     # Required because hc package default DNA name is working directory name
-    working_directory: ~/happ-example
+    working_directory: ~/happ-template
     steps:
       - checkout
       - run: |

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules/
 /target
 /result
+*.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,9 +204,9 @@ name = "example"
 version = "0.0.0"
 dependencies = [
  "boolinator 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hdk 0.0.39-alpha4",
+ "hdk 0.0.40-alpha1",
  "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_wasm_utils 0.0.39-alpha4",
+ "holochain_wasm_utils 0.0.40-alpha1",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -223,6 +223,29 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "futures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-executor 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "futures-channel-preview"
 version = "0.3.0-alpha.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,9 +255,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "futures-core-preview"
 version = "0.3.0-alpha.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "futures-executor-preview"
@@ -248,9 +286,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-io"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "futures-io-preview"
 version = "0.3.0-alpha.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "futures-preview"
@@ -266,11 +320,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "futures-sink-preview"
 version = "0.3.0-alpha.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures-core-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-macro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -315,15 +397,15 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.0.39-alpha4"
+version = "0.0.40-alpha1"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_core_types 0.0.39-alpha4",
+ "holochain_core_types 0.0.40-alpha1",
  "holochain_json_api 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_persistence_api 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_wasm_utils 0.0.39-alpha4",
+ "holochain_wasm_utils 0.0.40-alpha1",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -342,28 +424,22 @@ dependencies = [
 
 [[package]]
 name = "holochain_core_types"
-version = "0.0.39-alpha4"
+version = "0.0.40-alpha1"
 dependencies = [
  "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-channel-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-executor-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-io-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hcid 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_json_api 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_locksmith 0.0.39-alpha4",
+ "holochain_locksmith 0.0.40-alpha1",
  "holochain_logging 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_persistence_api 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lib3h_crypto_api 0.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lib3h_crypto_api 0.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mashup 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "multihash 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -419,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_locksmith"
-version = "0.0.39-alpha4"
+version = "0.0.40-alpha1"
 dependencies = [
  "backtrace 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -478,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasm_utils"
-version = "0.0.39-alpha4"
+version = "0.0.40-alpha1"
 dependencies = [
- "holochain_core_types 0.0.39-alpha4",
+ "holochain_core_types 0.0.40-alpha1",
  "holochain_json_api 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_persistence_api 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -535,7 +611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lib3h_crypto_api"
-version = "0.0.22"
+version = "0.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -772,8 +848,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "proc-macro-hack-impl"
 version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1274,12 +1365,21 @@ dependencies = [
 "checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+"checksum futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6f16056ecbb57525ff698bb955162d0cd03bee84e6241c27ff75c08d8ca5987"
+"checksum futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fcae98ca17d102fd8a3603727b9259fcf7fa4239b603d2142926189bc8999b86"
 "checksum futures-channel-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "21c71ed547606de08e9ae744bb3c6d80f5627527ef31ecf2a7210d0e67bc8fae"
+"checksum futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "79564c427afefab1dfb3298535b21eda083ef7935b4f0ecbfcb121f0aec10866"
 "checksum futures-core-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4b141ccf9b7601ef987f36f1c0d9522f76df3bba1cf2e63bfacccc044c4558f5"
+"checksum futures-executor 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e274736563f686a837a0568b478bdabfeaec2dca794b5649b04e2fe1627c231"
 "checksum futures-executor-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "87ba260fe51080ba37f063ad5b0732c4ff1f737ea18dcb67833d282cdc2c6f14"
+"checksum futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e676577d229e70952ab25f3945795ba5b16d63ca794ca9d2c860e5595d20b5ff"
 "checksum futures-io-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "082e402605fcb8b1ae1e5ba7d7fdfd3e31ef510e2a8367dd92927bb41ae41b3a"
+"checksum futures-macro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "52e7c56c15537adb4f76d0b7a76ad131cb4d2f4f32d3b0bcabcbe1c7c5e87764"
 "checksum futures-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "bf25f91c8a9a1f64c451e91b43ba269ed359b9f52d35ed4b3ce3f9c842435867"
+"checksum futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16"
 "checksum futures-sink-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4309a25a1069a1f3c10647b227b9afe6722b67a030d3f00a9cbdc171fc038de4"
+"checksum futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9"
+"checksum futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
 "checksum futures-util-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "af8198c48b222f02326940ce2b3aa9e6e91a32886eeaad7ca3b8e4c70daa3f4e"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
@@ -1295,7 +1395,7 @@ dependencies = [
 "checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
-"checksum lib3h_crypto_api 0.0.22 (registry+https://github.com/rust-lang/crates.io-index)" = "78219b823beb15d23a94a92c97806728ce6e14ad14c7c568b0b7ff7738b95832"
+"checksum lib3h_crypto_api 0.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "e77463e2d8d02b1f94fdf5cdd511f485fd42686548a47b594913db9244d538d2"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum lock_api 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e57b3997725d2b60dbec1297f6c2e2957cc383db1cebd6be812163f969c7d586"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
@@ -1324,7 +1424,9 @@ dependencies = [
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
 "checksum proc-macro-hack 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "463bf29e7f11344e58c9e01f171470ab15c925c6822ad75028cc1c0e1d1eb63b"
+"checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 "checksum proc-macro-hack-impl 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "38c47dcb1594802de8c02f3b899e2018c78291168a22c281be21ea0fb4796842"
+"checksum proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
 "checksum proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cd07deb3c6d1d9ff827999c7f9b04cdfd66b1b17ae508e14fe47b620f2282ae0"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ version = "0.0.0"
 dependencies = [
  "boolinator 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hdk 0.0.41-alpha4",
+ "hdk_proc_macros 0.0.41-alpha4",
  "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_wasm_utils 0.0.41-alpha4",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -412,6 +413,16 @@ dependencies = [
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hdk_proc_macros"
+version = "0.0.41-alpha4"
+dependencies = [
+ "hdk 0.0.41-alpha4",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -656,7 +667,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-hack 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -877,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -909,7 +920,7 @@ name = "quote"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1063,7 +1074,7 @@ name = "serde_derive"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1144,7 +1155,7 @@ name = "syn"
 version = "0.15.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1164,7 +1175,7 @@ name = "synstructure"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1329,7 +1340,7 @@ name = "zeroize_derive"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1428,7 +1439,7 @@ dependencies = [
 "checksum proc-macro-hack-impl 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "38c47dcb1594802de8c02f3b899e2018c78291168a22c281be21ea0fb4796842"
 "checksum proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
 "checksum proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cd07deb3c6d1d9ff827999c7f9b04cdfd66b1b17ae508e14fe47b620f2282ae0"
-"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+"checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eca14c727ad12702eb4b6bfb5a232287dcf8385cb8ca83a3eeaf6519c44c408"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,9 +204,9 @@ name = "example"
 version = "0.0.0"
 dependencies = [
  "boolinator 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hdk 0.0.41-alpha3",
+ "hdk 0.0.41-alpha4",
  "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_wasm_utils 0.0.41-alpha3",
+ "holochain_wasm_utils 0.0.41-alpha4",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -397,15 +397,15 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.0.41-alpha3"
+version = "0.0.41-alpha4"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_core_types 0.0.41-alpha3",
+ "holochain_core_types 0.0.41-alpha4",
  "holochain_json_api 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_persistence_api 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_wasm_utils 0.0.41-alpha3",
+ "holochain_wasm_utils 0.0.41-alpha4",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_core_types"
-version = "0.0.41-alpha3"
+version = "0.0.41-alpha4"
 dependencies = [
  "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -435,7 +435,7 @@ dependencies = [
  "hcid 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_json_api 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_locksmith 0.0.41-alpha3",
+ "holochain_locksmith 0.0.41-alpha4",
  "holochain_logging 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_persistence_api 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_locksmith"
-version = "0.0.41-alpha3"
+version = "0.0.41-alpha4"
 dependencies = [
  "backtrace 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasm_utils"
-version = "0.0.41-alpha3"
+version = "0.0.41-alpha4"
 dependencies = [
- "holochain_core_types 0.0.41-alpha3",
+ "holochain_core_types 0.0.41-alpha4",
  "holochain_json_api 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_persistence_api 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,9 +204,9 @@ name = "example"
 version = "0.0.0"
 dependencies = [
  "boolinator 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hdk 0.0.40-alpha1",
+ "hdk 0.0.41-alpha3",
  "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_wasm_utils 0.0.40-alpha1",
+ "holochain_wasm_utils 0.0.41-alpha3",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -397,15 +397,15 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.0.40-alpha1"
+version = "0.0.41-alpha3"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_core_types 0.0.40-alpha1",
+ "holochain_core_types 0.0.41-alpha3",
  "holochain_json_api 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_persistence_api 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_wasm_utils 0.0.40-alpha1",
+ "holochain_wasm_utils 0.0.41-alpha3",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_core_types"
-version = "0.0.40-alpha1"
+version = "0.0.41-alpha3"
 dependencies = [
  "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -435,7 +435,7 @@ dependencies = [
  "hcid 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_json_api 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_locksmith 0.0.40-alpha1",
+ "holochain_locksmith 0.0.41-alpha3",
  "holochain_logging 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_persistence_api 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_locksmith"
-version = "0.0.40-alpha1"
+version = "0.0.41-alpha3"
 dependencies = [
  "backtrace 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasm_utils"
-version = "0.0.40-alpha1"
+version = "0.0.41-alpha3"
 dependencies = [
- "holochain_core_types 0.0.40-alpha1",
+ "holochain_core_types 0.0.41-alpha3",
  "holochain_json_api 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_persistence_api 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -764,7 +764,7 @@ name = "num_cpus"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1384,7 +1384,7 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 "checksum hcid 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5ea27f6b17df2ded5dcfc492ecd0db719d00b144dbaaf2df1658a7e38cfd2e"
-"checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
+"checksum hermit-abi 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f629dc602392d3ec14bfc8a09b5e644d7ffd725102b48b81e59f90f2633621d7"
 "checksum holochain_json_api 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7411832f446f09ea53ce2ca789fd2acd86ad29cc08d6d3c903474c2fada54ca5"
 "checksum holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "b82510813b7164094ca380651f81350d461fb695f4580c4d25d9f52bcc5e1f5d"
 "checksum holochain_logging 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1eea83e3663d88570a6443db7dbfcabe6fb50797c5b0384d096ca835938bc366"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 
 exclude = [
-"holochain-rust",
+  "holochain-rust",
 ]
 
 members = [

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test-node:
 
 test-sim2h:
 	@echo "Starting sim2h_server on localhost:9000 (may already be running)..."; \
-	    sim2h_server -p 9000 &
+	    sim2h_server -p 9000 >sim2h_server.log 2>&1 &
 
 # Generic targets; does not require a Nix environment
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@
 # 
 # This Makefile is primarily instructional; you can simply enter the Nix environment for
 # holochain-rust development (supplied by holo=nixpkgs; see pkgs.nix) via `nix-shell` and run `hc
-# test` directly, or build a target directly (see default.nix), eg. `nix-build -A happ-example`.
+# test` directly, or build a target directly (see default.nix), eg. `nix-build -A happ-template`.
 # 
 SHELL		= bash
-DNANAME		= happ-example
+DNANAME		= happ-template
 DNAZOME		= example
 DNA		= dist/$(DNANAME).dna.json
 
@@ -50,15 +50,17 @@ test-unit:
 	RUST_BACKTRACE=1 cargo test \
 	    -- --nocapture
 
+test-dna:	$(DNA)
+
 # End-to-end test of DNA.  Runs a sim2h_server on localhost:9000; the default expected by `hc test`
-test-e2e:	$(DNA) test-sim2h test-node
+test-e2e:	test-dna test-sim2h test-node
 	@echo "Starting Scenario tests..."; \
 	    RUST_BACKTRACE=1 hc test \
-	        | test/node_modules/faucet/bin/cmd.js
+	        | node test/node_modules/faucet/bin/cmd.js
 
 test-node:
 	@echo "Setting up Scenario/Stress test Javascript..."; \
-	    cd test && npm install
+	    cd test && [ -d node_modules ] || npm install
 
 test-sim2h:
 	@echo "Starting sim2h_server on localhost:9000 (may already be running)..."; \

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import ./pkgs.nix, shell ? false }:
+{ pkgs ? import ./pkgs.nix {}, shell ? false }:
 
 with pkgs;
 

--- a/default.nix
+++ b/default.nix
@@ -13,7 +13,12 @@ in
     name = "happ-example";
     src = gitignoreSource ./.;
 
-    nativeBuildInputs = []
+    nativeBuildInputs = [
+      cmake # required by wabt
+      binaryen
+      wasm-gc
+      wabt
+    ]
     ++ lib.optionals stdenv.isDarwin [ CoreServices ];
   };
 }

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import ./pkgs.nix {} }:
+{ pkgs ? import ./pkgs.nix, shell ? false }:
 
 with pkgs;
 
@@ -8,6 +8,8 @@ in
 
 {
   happ-example = buildDNA {
+    inherit shell;
+
     name = "happ-example";
     src = gitignoreSource ./.;
 

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/8b8da7f30d7940abeb463ca5b5a6fd3df1ad7bae.tar.gz";
-  sha256 = "0wckq3fcgwva9mpa1857d7s118x2np0n11v3wiljmxalny1df023";
+  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/998bc9e6a8e61bde47485e0ef90b51cec70a3786.tar.gz";
+  sha256 = "127021rzh9dq87a6v118c5n6jrjhhxv4hdvvprra21jmgfw8nk73";
 })

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/998bc9e6a8e61bde47485e0ef90b51cec70a3786.tar.gz";
-  sha256 = "127021rzh9dq87a6v118c5n6jrjhhxv4hdvvprra21jmgfw8nk73";
+  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/8455f9413346a02ad8d50f1a210b5ff884dbc5d7.tar.gz";
+  sha256 = "1p10g3ngjhnhs053rs3x2vy2fbryjx31p9afvi50yjxpkkfbl1xw";
 })

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/8455f9413346a02ad8d50f1a210b5ff884dbc5d7.tar.gz";
-  sha256 = "1p10g3ngjhnhs053rs3x2vy2fbryjx31p9afvi50yjxpkkfbl1xw";
+  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/88a325b9b03976d5d84872283f737bd76b8cb7ca.tar.gz";
+  sha256 = "1ma17fpdibdl1clfrpsk2jpa2b9kfyq99nxv82vh6v6wzjd4ml6m";
 })

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/88a325b9b03976d5d84872283f737bd76b8cb7ca.tar.gz";
-  sha256 = "1ma17fpdibdl1clfrpsk2jpa2b9kfyq99nxv82vh6v6wzjd4ml6m";
+  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/a1b09bdc64ed0e512a1a693493bbfb47253902f7.tar.gz";
+  sha256 = "0xj2d37h6dn0z4qqbdvk4378vninis7kwidnpnh3696fx9v1jy7f";
 })

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/0bc27765870a23083fecf9edbf57a819548288a2.tar.gz";
-  sha256 = "1y5c4y5flsrsmb947757d3b64zzqry1rnlvv4y0wchji7b72wi85";
+  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/fc160c13bd2f88409d09866ea59945b9579dd23a.tar.gz";
+  sha256 = "09wsb9n62rxgr4pqz2z1098xcj8fqwxnq0iv0lhprj15vbkxpgih";
 })

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/a1b09bdc64ed0e512a1a693493bbfb47253902f7.tar.gz";
-  sha256 = "0xj2d37h6dn0z4qqbdvk4378vninis7kwidnpnh3696fx9v1jy7f";
+  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/0bc27765870a23083fecf9edbf57a819548288a2.tar.gz";
+  sha256 = "1y5c4y5flsrsmb947757d3b64zzqry1rnlvv4y0wchji7b72wi85";
 })

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,14 @@
-(import ./. {}).happ-example.override { shell = true; }
+{ pkgs ? import ./pkgs.nix {}, shell ? false }:
+
+with pkgs;
+
+mkShell {
+  inputsFrom = lib.attrValues  (import ./. {
+    inherit pkgs;
+    shell = true;
+  });
+
+  buildInputs = [
+    # additional packages go here
+  ];
+}

--- a/test/config.js
+++ b/test/config.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const { Config } = require('@holochain/tryorama')
 
-const dnaName = "happ-example"
+const dnaName = "happ-template"
 const dnaId = "example"
 
 const dnaPath = path.join(__dirname, `../dist/${dnaName}.dna.json`)

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -13,17 +13,17 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-      "integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
+      "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
     },
     "@holochain/hachiko": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@holochain/hachiko/-/hachiko-0.4.1.tgz",
-      "integrity": "sha512-IEkdz7I7tjRwYuGW1+Q8yqvawR70xfu9W9dWVxNDOhvqByoHgMGL90BxF3H1HbVOxlaPYuLbHogp8sRttserQg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@holochain/hachiko/-/hachiko-0.5.1.tgz",
+      "integrity": "sha512-4qY8mNaOZ/YVXdeeuYVOHcA6tXpksxGA64qHILnO/BHxqNt4q8KOUlIYJQYB/wCddGz+DzYU0k+/v5475O2dqA==",
       "requires": {
         "colors": "^1.3.3",
         "lodash": "^4.17.15",
@@ -32,20 +32,20 @@
       }
     },
     "@holochain/hc-web-client": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@holochain/hc-web-client/-/hc-web-client-0.5.0.tgz",
-      "integrity": "sha512-p+Q3rRg+ODfW2w65SteeiPL3Do43rWztioC1V05tiPvzDaupUUMtf7mXOoLwYFoqYnHYvbMsTBPIh7RpSt907w==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@holochain/hc-web-client/-/hc-web-client-0.5.1.tgz",
+      "integrity": "sha512-4MFtu/G/PZksj4ouzldJ3SQrllE7108u96ZU92C1iJxlxsyvnSli4MSyTpEolnT5KsW9bNF4pzGTIgam/3V8/A==",
       "requires": {
         "isomorphic-fetch": "^2.2.1",
         "rpc-websockets": "^4.3.3"
       }
     },
     "@holochain/tryorama": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@holochain/tryorama/-/tryorama-0.2.0.tgz",
-      "integrity": "sha512-d1SM+2kn80RLSIN7NCAtDZB7JfWu8e1BYfusC1m+WTt1yi7leGG5BhAmpseYjO+zu7g8tGLvkwGyIC/8XoZpUw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@holochain/tryorama/-/tryorama-0.3.1.tgz",
+      "integrity": "sha512-DGeUZkh+OCR8/l9hvpJLqqJeakK5Ujs4mEi/7vz1BuBfFwSNfxRhr7029qljMgE5uUg4m7UKCWauBHUyBcF7JA==",
       "requires": {
-        "@holochain/hachiko": "^0.4.1",
+        "@holochain/hachiko": "^0.5.1",
         "@holochain/hc-web-client": "^0.5.0",
         "@iarna/toml": "^2.2.3",
         "async-mutex": "^0.1.4",
@@ -58,7 +58,6 @@
         "io-ts-reporters": "^1.0.0",
         "lodash": "^4.17.15",
         "memoizee": "^0.4.14",
-        "moniker": "^0.1.2",
         "ramda": "^0.26.1",
         "uuid": "^3.3.3",
         "winston": "^3.2.1"
@@ -215,9 +214,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "core-js": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -262,9 +261,17 @@
       }
     },
     "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -317,27 +324,21 @@
       "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA=="
     },
     "es-abstract": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",
-      "integrity": "sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
+      "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
-        "string.prototype.trimleft": "^2.1.0",
-        "string.prototype.trimright": "^2.1.0"
-      },
-      "dependencies": {
-        "object-inspect": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-          "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
-        }
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
       }
     },
     "es-to-primitive": {
@@ -405,9 +406,9 @@
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "ext": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.3.0.tgz",
-      "integrity": "sha512-LErT9cIGZZjSvFkyocVXXeYlj7z8xiA+4oQlM9cX4X/Kfc18cefv3Dd9mNKwFuzUJ7neMMAQz1u1r3gBa/6wGg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
       "requires": {
         "type": "^2.0.0"
       },
@@ -510,9 +511,9 @@
       }
     },
     "fp-ts": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.2.0.tgz",
-      "integrity": "sha512-muJL9NOYluuoRezrvOyQvLAHIXrYg7u/Tc6cu4PP/Ed4TJKrm6BVSX8H1goT/4nhgP/yQ+Z4Xjjt4ijeKFX4Ng=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.3.1.tgz",
+      "integrity": "sha512-KevPBnYt0aaJiuUzmU9YIxjrhC9AgJ8CLtLlXmwArovlNTeYM5NtEoKd86B0wHd7FIbzeE8sNXzCoYIOr7e6Iw=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -525,12 +526,9 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "get-port": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.0.0.tgz",
-      "integrity": "sha512-imzMU0FjsZqNa6BqOjbbW6w5BivHIuQKopjpPqcnx0AVHJQKCxK1O+Ab3OrVXhrekqfVMjwA9ZYu062R+KcIsQ==",
-      "requires": {
-        "type-fest": "^0.3.0"
-      }
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.0.tgz",
+      "integrity": "sha512-bjioH1E9bTQUvgaB6VycVy1QVbTZI41yTnF9qkZz6ixgy/uhCH6D63bKeZ6Code/07JYA61MeI94jSdHss8PNA=="
     },
     "get-prototype-of": {
       "version": "0.0.0",
@@ -586,9 +584,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "io-ts": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.0.1.tgz",
-      "integrity": "sha512-RezD+WcCfW4VkMkEcQWL/Nmy/nqsWTvTYg7oUmTGzglvSSV2P9h2z1PVeREPFf0GWNzruYleAt1XCMQZSg1xxQ=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.0.3.tgz",
+      "integrity": "sha512-PLSW+/QELUEmt68jmS+1JOxDzK3jrNlfiCTb62mQYV7RfixuUHga+Up4gszLqLAtNOUSjv9UmqNX0n/tgpzniA=="
     },
     "io-ts-reporters": {
       "version": "1.0.0",
@@ -598,6 +596,11 @@
         "fp-ts": "^2.0.2",
         "io-ts": "^2.0.0"
       }
+    },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
     },
     "is-arrayish": {
       "version": "0.3.2",
@@ -610,9 +613,9 @@
       "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
     },
     "is-capitalized": {
       "version": "1.0.0",
@@ -625,9 +628,9 @@
       "integrity": "sha1-4FdFFwW7NOOePjNZjJOpg3KWtzY="
     },
     "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-promise": {
       "version": "2.1.0",
@@ -635,11 +638,11 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "requires": {
-        "has": "^1.0.1"
+        "has": "^1.0.3"
       }
     },
     "is-stream": {
@@ -744,11 +747,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
-    "moniker": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/moniker/-/moniker-0.1.2.tgz",
-      "integrity": "sha1-hy37pXXc6o+gSlE1sT1fJL7MyX4="
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -769,14 +767,30 @@
       }
     },
     "object-inspect": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+    },
+    "object-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -826,10 +840,19 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
       "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
+    "regexp.prototype.flags": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
+    },
     "resolve": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.1.tgz",
+      "integrity": "sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==",
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -891,28 +914,28 @@
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "string.prototype.trim": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
-      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
+      "integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.0",
-        "function-bind": "^1.0.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1"
       }
     },
     "string.prototype.trimleft": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
-      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
       }
     },
     "string.prototype.trimright": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
-      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
@@ -963,22 +986,23 @@
       }
     },
     "tape": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.11.0.tgz",
-      "integrity": "sha512-yixvDMX7q7JIs/omJSzSZrqulOV51EC9dK8dM0TzImTIkHWfe2/kFyL5v+d9C+SrCMaICk59ujsqFAVidDqDaA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.12.1.tgz",
+      "integrity": "sha512-xoK2ariLmdGxqyXhhxfIZlr0czNB8hNJeVQmHN4D7ZyBn30GUoa4q2oM4cX8jNhnj1mtILXn1ugbfxc0tTDKtA==",
       "requires": {
-        "deep-equal": "~1.0.1",
+        "deep-equal": "~1.1.1",
         "defined": "~1.0.0",
         "for-each": "~0.3.3",
         "function-bind": "~1.1.1",
-        "glob": "~7.1.4",
+        "glob": "~7.1.6",
         "has": "~1.0.3",
         "inherits": "~2.0.4",
+        "is-regex": "~1.0.5",
         "minimist": "~1.2.0",
-        "object-inspect": "~1.6.0",
-        "resolve": "~1.11.1",
+        "object-inspect": "~1.7.0",
+        "resolve": "~1.14.1",
         "resumer": "~0.0.0",
-        "string.prototype.trim": "~1.1.2",
+        "string.prototype.trim": "~1.2.1",
         "through": "~2.3.8"
       }
     },
@@ -1051,11 +1075,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
       "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
-    },
-    "type-fest": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/test/package.json
+++ b/test/package.json
@@ -3,7 +3,7 @@
     "faucet": "0.0.1"
   },
   "dependencies": {
-    "@holochain/tryorama": "^0.2.0-rc.5",
+    "@holochain/tryorama": "^0.3.1",
     "tape": "^4.11.0"
   },
   "scripts": {}

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -2,18 +2,12 @@ const { one } = require('./config')
 
 module.exports = scenario => {
 
-
 // Create and Get an entry
 scenario('Can create/get entry', async (s, t) => {
-    const { alice, bob } = await s.players({alice: one('alice'), bob: one('bob')}, true)
+    const { alice } = await s.players({alice: one('alice')}, true)
     
     console.log("Starting happ-example 'smoke' test")
-
-    // Ensure that the Scenerio test Agent IDs are set, and not identical
-    t.ok(alice.info('app').agentAddress)
-    t.notEqual(alice.info('app').agentAddress, bob.info('app').agentAddress)
-
-    // See if the Agent's Zome whoami API returns real data
+    
     var create = await alice.call( 'app', "example", "create_my_entry", { entry: { content: "Hello, world!" }} );
     console.log("***DEBUG***: create == " + JSON.stringify( create ))
     t.isEquivalent( create.Ok, "QmPipFWaSttS4kroTMYxvW6kKd9rTZcKpPmuM817qGus7c" )
@@ -21,6 +15,39 @@ scenario('Can create/get entry', async (s, t) => {
     // Now, get the entry back.  Any agent can get back any entry (they are CAS addresses)
     var get = await alice.call( 'app', "example", "get_my_entry", { address: create.Ok } );
     t.isEquivalent( get.Ok, { App: [ 'my_entry', '{"content":"Hello, world!"}' ] } )
+})
+
+
+scenario('Can identify identity and HDK environment', async (s, t) => {
+    const { alice, bob } = await s.players({alice: one('alice'), bob: one('bob')}, true)
+
+    // Ensure that the Scenerio test Agent IDs are set, and not identical
+    t.ok(alice.info('app').agentAddress)
+    t.notEqual(alice.info('app').agentAddress, bob.info('app').agentAddress)
+
+    // Ensure that whoami Zome API agrees
+    var alice_whoami = await alice.call( 'app', "example", "whoami", {} );
+    console.log("***DEBUG***: whoami == " + JSON.stringify( alice_whoami, null, 2 ))
+    t.ok(alice_whoami.Ok)
+
+    // See if the Agent's Zome whoami API returns real data
+    t.isEqual(alice_whoami.Ok.agent_address, alice.info('app').agentAddress)
+    t.isEquivalent(alice_whoami.Ok.dna_name, "Example")
+})
+
+
+scenario('Can send/receive Message', async (s, t) => {
+    const { alice, bob } = await s.players({alice: one('alice'), bob: one('bob')}, true)
+
+    // Send a Message containing some arbitrary Ping data, and ensure we get a Pong back.
+    const body = JSON.stringify({"key": "value"})
+    const message_reply = await alice.call( 'app', "example", "send_message", {
+	to: bob.info('app').agentAddress,
+	message: { Ping: "hello" },
+	timeout: "2500ms",
+    })
+    console.log("***DEBUG***: message_reply == " + JSON.stringify( message_reply, null, 2 ))
+    t.isEquivalent( message_reply.Ok, { Pong: [ alice.info('app').agentAddress, "hello" ] })
 })
 
 }

--- a/zomes/example/code/.hcbuild
+++ b/zomes/example/code/.hcbuild
@@ -7,6 +7,36 @@
         "--release",
         "--target=wasm32-unknown-unknown"
       ]
+    },
+    {
+      "command": "wasm-gc",
+      "arguments": ["../../../target/wasm32-unknown-unknown/release/example.wasm"]
+    },
+    {
+      "command": "wasm-opt",
+      "arguments": [
+        "-Oz",
+        "--vacuum",
+        "../../../target/wasm32-unknown-unknown/release/example.wasm",
+        "-o",
+        "../../../target/wasm32-unknown-unknown/release/example.wasm.opt"
+      ]
+    },
+    {
+      "command": "wasm2wat",
+      "arguments": [
+        "../../../target/wasm32-unknown-unknown/release/example.wasm.opt",
+        "-o",
+        "../../../target/wasm32-unknown-unknown/release/example.wat"
+      ]
+    },
+    {
+      "command": "wat2wasm",
+      "arguments": [
+        "../../../target/wasm32-unknown-unknown/release/example.wat",
+        "-o",
+        "../../../target/wasm32-unknown-unknown/release/example.wasm"
+      ]
     }
   ],
   "artifact": "../../../target/wasm32-unknown-unknown/release/example.wasm"

--- a/zomes/example/code/Cargo.toml
+++ b/zomes/example/code/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 boolinator = "2.4.0"
 hdk = { path = "../../../holochain-rust/crates/hdk" }
 holochain_wasm_utils = { path = "../../../holochain-rust/crates/wasm_utils" }
+hdk_proc_macros = { path = "../../../holochain-rust/crates/hdk_v2" }
 holochain_json_derive = "=0.0.17"
 serde = "=1.0.89"
 serde_json = { version = "=1.0.39", features = [ "preserve_order" ] }

--- a/zomes/example/code/src/lib.rs
+++ b/zomes/example/code/src/lib.rs
@@ -1,29 +1,38 @@
+#![feature(slice_patterns)]
+#![feature(proc_macro_hygiene)]
 #[macro_use]
 extern crate hdk;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
 extern crate serde_json;
 #[macro_use]
 extern crate holochain_json_derive;
 
+extern crate hdk_proc_macros;
+use hdk_proc_macros::zome;
+
 use hdk::{
+    AGENT_ADDRESS, AGENT_ID_STR, DNA_ADDRESS, DNA_NAME,
     entry_definition::ValidatingEntryType,
-    error::ZomeApiResult,
-};
-use hdk::holochain_core_types::{
-    entry::Entry,
-    dna::entry_types::Sharing,
+    error::{ZomeApiResult, ZomeApiError},
+    holochain_core_types::{
+        agent::AgentId,
+        dna::entry_types::Sharing,
+        entry::Entry,
+        time::{Period, Timeout},
+    },
+    holochain_json_api::{
+        error::JsonError,
+        json::JsonString,
+    },
+    holochain_persistence_api::{
+        cas::content::Address,
+    },
 };
 
-use hdk::holochain_persistence_api::{
-    cas::content::Address,
-};
-
-use hdk::holochain_json_api::{
-    error::JsonError,
-    json::JsonString,
-};
+use std::convert::TryInto;
 
 
 // see https://developer.holochain.org/api/{{ version }}/hdk/ for info on using the hdk library
@@ -31,63 +40,347 @@ use hdk::holochain_json_api::{
 // This is a sample zome that defines an entry type "MyEntry" that can be committed to the
 // agent's chain via the exposed function create_my_entry
 
-#[derive(Serialize, Deserialize, Debug, DefaultJson,Clone)]
+#[derive(Serialize, Deserialize, Debug, DefaultJson, Clone)]
 pub struct MyEntry {
     content: String,
 }
 
-pub fn handle_create_my_entry(entry: MyEntry) -> ZomeApiResult<Address> {
-    let entry = Entry::App("my_entry".into(), entry.into());
-    let address = hdk::commit_entry(&entry)?;
-    Ok(address)
+
+#[derive(Serialize, Deserialize, Debug, DefaultJson, PartialEq)]
+pub struct WhoamiResult {
+    pub hdk_version:	String,
+    pub hdk_hash:	String,
+    pub dna_address:	String,
+    pub dna_name:	String,
+    pub agent_id:	AgentId,
+    pub agent_address:	String,
 }
 
-pub fn handle_get_my_entry(address: Address) -> ZomeApiResult<Option<Entry>> {
-    hdk::get_entry(&address)
+/// whoami_internal -- Return details of the local Agent or (if specified) some other Agent
+pub fn whoami_internal() -> ZomeApiResult<WhoamiResult> {
+    Ok(WhoamiResult {
+        hdk_version: hdk::version()?,
+        hdk_hash: hdk::version_hash()?,
+        dna_name: DNA_NAME.to_string(),
+        dna_address: DNA_ADDRESS.to_string(),
+        agent_id: JsonString::from_json(&AGENT_ID_STR).try_into()?,
+        agent_address: AGENT_ADDRESS.to_string(),
+    })
 }
 
-fn definition() -> ValidatingEntryType {
-    entry!(
-        name: "my_entry",
-        description: "this is a same entry defintion",
-        sharing: Sharing::Public,
-        validation_package: || {
-            hdk::ValidationPackageDefinition::Entry
-        },
 
-        validation: | _validation_data: hdk::EntryValidationData<MyEntry>| {
-            Ok(())
-        }
-    )
+#[derive(Serialize, Deserialize, Debug, DefaultJson, PartialEq)]
+pub enum Message {
+    None,
+    Ping(String),
+    Pong((Address, String))
 }
 
-define_zome! {
-    entries: [
-       definition()
-    ]
+/// receive_responder -- returns the supplied arbitrary JSON-encoded payload via a JSON-encoded ZomeApiResult
+pub fn receive_responder(
+    from: Address,
+    payload: JsonString
+) -> JsonString {
+    // Attempt to parse the provide JSON as the expected payload Message type, returning a
+    // valid-looking JSON ZomeApiResult on Error (we could do this in various more direct ways...)
+    //println!("receive_responder: received: from: {:?}, payload: {:?}", &from, &payload);
+    let message: Message = match payload.try_into() {
+        Ok(message) => message,
+        Err(e) =>
+            return json!({
+                "Err": {
+                    "HolochainError": {
+                        "message": format!(
+                            "receive_responder: Failed to parse JSON payload as Message: {}",
+                            e )
+                    }
+                }
+            }).into(),
+    };
 
-    init: || { Ok(()) }
+    // Formulate the response Ok/Err ZomeApiResult, convert to JSON
+    let response = JsonString::from(responder(from, message));
+    //println!("receive_responder: response: {:?}", &response);
+    response
+}
 
-    validate_agent: |validation_data : EntryValidationData::<AgentId>| {
+/// responder -- Process the decoded inter-agent Message, yielding Ok/Err Result Message
+pub fn responder(
+    from: Address,
+    message: Message
+) -> ZomeApiResult<Message> {
+    //println!("responder: message: {:?}", &message);
+    Ok(match message {
+        Message::None => Message::None,
+        Message::Ping(ping) => Message::Pong((from, ping)),
+        Message::Pong(pong) => return Err(ZomeApiError::Internal(
+            format!("Unhandled: {:?}", Message::Pong(pong))
+        )),
+    })
+}
+
+
+#[zome]
+pub mod example {
+
+    #[init]
+    fn init() {
         Ok(())
     }
 
-    receive: |_from, _payload| { "".to_string() }
-
-    functions: [
-        create_my_entry: {
-            inputs: |entry: MyEntry|,
-            outputs: |result: ZomeApiResult<Address>|,
-            handler: handle_create_my_entry
-        }
-        get_my_entry: {
-            inputs: |address: Address|,
-            outputs: |result: ZomeApiResult<Option<Entry>>|,
-            handler: handle_get_my_entry
-        }
-    ]
-
-    traits: {
-        hc_public [create_my_entry,get_my_entry]
+    #[validate_agent]
+    pub fn validate_agent(validation_data: EntryValidationData<AgentId>) {
+        Ok(())
     }
+
+    #[receive]
+    fn receive(from: Address, payload_json: String) {
+        //println!("receive: from: {:?}: {:?}", &from, &payload_json);
+        let response_json = receive_responder(from, JsonString::from_json(&payload_json)).to_string();
+        //println!("receive: response: {:?}", &response_json);
+        response_json
+    }
+
+    #[entry_def]
+    fn my_entry_definition() -> ValidatingEntryType {
+        entry!(
+            name: "my_entry",
+            description: "this is my entry definition",
+            sharing: Sharing::Public,
+            validation_package: || {
+                hdk::ValidationPackageDefinition::Entry
+            },
+
+            validation: | _validation_data: hdk::EntryValidationData<MyEntry>| {
+                Ok(())
+            }
+        )
+    }
+
+    #[zome_fn("hc_public")]
+    fn whoami() -> ZomeApiResult<WhoamiResult> {
+        whoami_internal()
+    }
+
+    #[zome_fn("hc_public")]
+    fn create_my_entry(
+        entry: MyEntry
+    ) -> ZomeApiResult<Address> {
+        let entry = Entry::App("my_entry".into(), entry.into());
+        let address = hdk::commit_entry(&entry)?;
+        Ok(address)
+    }
+
+    #[zome_fn("hc_public")]
+    fn get_my_entry(
+        address: Address
+    ) -> ZomeApiResult<Option<Entry>> {
+        hdk::get_entry(&address)
+    }
+
+    /// send_message -- Carries an arbitrary Message type via JSON Strings to/from counterparty Agent
+    #[zome_fn("hc_public")]
+    fn send_message(
+        to: Address,
+        message: Message,
+        timeout: Option<Period> // eg. "2500ms", "1m30s"
+    ) -> ZomeApiResult<Message> {
+        // Encode the Message to a JSON-encoded String
+        let timeout = match timeout {
+            Some(period) => period.into(),
+            None => Timeout::from(5000),
+        };
+        hdk::debug(format!("send_message: message: {:?}", &message)).ok();
+        let message_json: String = JsonString::from( message ).to_string();
+        hdk::debug(format!("send_message: message_json: {:?}", &message_json)).ok();
+
+        // Raw agent-agent communication occurs as Strings, with the designated timeout
+        let reply_json: String = hdk::send( to, message_json, timeout )?;
+
+        // Decode the JSON-encoded ZomeApiResult-wrapped reply Message
+        hdk::debug(format!("send_message: reply_json: {:?}", &reply_json)).ok();
+        let reply = JsonString::from_json( &reply_json );
+        let result: ZomeApiResult<Message> = reply.try_into()?;
+        hdk::debug(format!("send_message: result: {:?}", &result)).ok();
+        result
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use crate::*;
+
+    use hdk::{
+        holochain_core_types::{
+            error::{
+                RibosomeEncodedValue, RibosomeEncodingBits,
+            },
+        },
+    };
+
+    // See .../holochain-rust/crates/core/src/nucleus/ribosome/api/mod.rs for definitive list
+    #[no_mangle]
+    pub fn hc_debug(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_commit_entry(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_get_entry(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_update_entry(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_remove_entry(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_init_globals(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_call(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_link_entries(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_get_links(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_get_links_count(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_query(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_entry_address(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_send(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_sleep(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_remove_link(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_crypto(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_sign_one_time(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_verify_signature(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_keystore_list(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_keystore_new_random(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_keystore_derive_seed(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_keystore_derive_key(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_keystore_sign(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_keystore_get_public_key(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_commit_capability_grant(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_commit_capability_claim(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_emit_signal(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[no_mangle]
+    pub fn hc_meta(_: RibosomeEncodingBits) -> RibosomeEncodingBits {
+        RibosomeEncodedValue::Success.into()
+    }
+
+    #[test]
+    fn smoke() {
+        // Lets confirm transport of some arbitrary JSON carried via send/receive 
+        let body = JsonString::from( "My hovercraft is full of eels!" );
+        let address = Address::from( "HcScjwO9ji9633ZYxa6IYubHJHW6ctfoufv5eq4F7ZOxay8wR76FP4xeG9pY3ui" );
+        let payload_json = JsonString::from(Message::Ping(body.to_string()));
+
+        let response = receive_responder( address.clone(), payload_json );
+
+        //println!( "response: {:?}", &response );
+        let received_maybe: Result<ZomeApiResult<Message>, _> = response.try_into();
+        assert!( received_maybe.is_ok() );
+        if received_maybe.is_ok() {
+            let received = received_maybe.unwrap();
+            //println!( "received: {:?}", &received );
+            assert!( received.is_ok() );
+            if received.is_ok() {
+                // And lets confirm that our Ping round-tripped
+                assert_eq!( received.unwrap(), Message::Pong((address,body.to_string())));
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Updated the happ-template example to HC 0.0.41-alpha4, and:
    o Change name to hdk-template
    o Add Rust and Scenario tests
    o Convert to HDKv2 Zome definition proc macros
    o Provide examples of hdk::send/receive, accessing HDK constants
    o Implement WASM optimizations in .hcbuild